### PR TITLE
Lint

### DIFF
--- a/memegen.sh
+++ b/memegen.sh
@@ -38,7 +38,7 @@ footer="$(echo "$4" | awk '{print toupper($0)}')"
 
 if [ -e "$dest" ]; then
   printf "%s exists, override? [Y|n] " "$dest"
-  read response
+  read -r response
   if [ -z "$response" ] || [ "$response" = "y" ]; then
     rm -f "$dest"
   else
@@ -72,7 +72,7 @@ fi
 
 font=Impact
 
-width=$(identify -format %w ${src})
+width=$(identify -format %w "${src}")
 caption_height=$((width/6))
 stroke_width=$((width/400 > 1 ? width/400 : 1))
 


### PR DESCRIPTION
Hey, first of all thanks for your wonderful project!

[Shellcheck](https://www.shellcheck.net/) has found two minor problems:

- Line 41: [SC2162](https://www.shellcheck.net/wiki/SC2162): read without -r will mangle backslashes.
  - This shouldn't be a problem as we're only asking for a y/n answer here, but as a general rule it's better just to stick to `read -r` unless you explicitly want backslash escapes to work.
 
- Line 75: [SC2086](https://www.shellcheck.net/wiki/SC2086): Double quote to prevent globbing and word splitting.
  - This could cause problems when `src` contains whitespace (e. g. `/home/user/Meme templates/me.jpg`).