### PR TITLE
fix: update the deprecated `convert` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A POSIX shell script to generate memes from the commandline using ImageMagick
 ## Requirements
 
 - ImageMagick installed
-- Impact font installed properly. Check: `convert -list font | grep Impact`
+- Impact font installed properly. Check: `magick -list font | grep Impact`
 
 ## Usage
 

--- a/memegen.sh
+++ b/memegen.sh
@@ -76,7 +76,7 @@ width=$(identify -format %w "${src}")
 caption_height=$((width/6))
 stroke_width=$((width/400 > 1 ? width/400 : 1))
 
-convert "$src" \
+magick "$src" \
   -background none \
   -font "$font" \
   -fill white \


### PR DESCRIPTION
`convert` is deprecated in ImageMagick v7 and replaced by just `magick`.
see the "Command Changes" section in https://imagemagick.org/script/porting.php
